### PR TITLE
Add keyfob scanner app

### DIFF
--- a/firmware/application/CMakeLists.txt
+++ b/firmware/application/CMakeLists.txt
@@ -307,10 +307,11 @@ set(CPPSRC
 	apps/ui_settings.cpp
 	apps/ui_siggen.cpp
 	apps/ui_sonde.cpp
-	apps/ui_ss_viewer.cpp
-	apps/ui_standalone_view.cpp
-	apps/ui_subghzd.cpp
-	# apps/ui_test.cpp
+        apps/ui_ss_viewer.cpp
+        apps/ui_standalone_view.cpp
+        apps/ui_subghzd.cpp
+        apps/ui_keyfob_scan.cpp
+        # apps/ui_test.cpp
 	apps/ui_text_editor.cpp
 	apps/ui_touch_calibration.cpp
 	apps/ui_touchtunes.cpp

--- a/firmware/application/apps/ui_keyfob_scan.cpp
+++ b/firmware/application/apps/ui_keyfob_scan.cpp
@@ -1,0 +1,184 @@
+#include "ui_keyfob_scan.hpp"
+#include "portapack.hpp"
+#include "audio.hpp"
+#include "file.hpp"
+#include "file_path.hpp"
+#include "io_convert.hpp"
+#include "capture_thread.hpp"
+#include "replay_thread.hpp"
+#include "oversample.hpp"
+#include "transmitter_model.hpp"
+
+using namespace portapack;
+
+namespace ui {
+
+KeyfobScanView::KeyfobScanView(NavigationView& nav)
+    : nav_{nav} {
+    add_children({&rssi, &field_frequency, &button_toggle, &button_transmit, &text_status});
+
+    baseband::run_image(portapack::spi_flash::image_tag_subghzd);
+    baseband::set_subghzd_config(0, receiver_model.sampling_rate());
+    receiver_model.enable();
+
+    field_frequency.set_step(100000);
+    field_frequency.set_value(freqs_[freq_index_]);
+
+    button_toggle.on_select = [this](Button&) { toggle_scanning(); };
+    button_transmit.on_select = [this](Button&) { transmit_last(); };
+    button_transmit.disabled(true);
+
+    signal_token_tick_second = rtc_time::signal_tick_second += [this]() {
+        this->on_tick_second();
+    };
+}
+
+KeyfobScanView::~KeyfobScanView() {
+    rtc_time::signal_tick_second -= signal_token_tick_second;
+    stop_capture();
+    stop_transmit();
+    receiver_model.disable();
+    baseband::shutdown();
+}
+
+void KeyfobScanView::focus() {
+    button_toggle.focus();
+}
+
+void KeyfobScanView::toggle_scanning() {
+    if (scanning_) {
+        scanning_ = false;
+        button_toggle.set_text("Start");
+        text_status.set("Stopped");
+    } else {
+        stop_capture();
+        stop_transmit();
+        scanning_ = true;
+        button_toggle.set_text("Stop");
+        text_status.set("Scanning");
+    }
+}
+
+void KeyfobScanView::on_tick_second() {
+    if (capturing_) {
+        if (capture_seconds_left_ > 0 && --capture_seconds_left_ == 0) {
+            stop_capture();
+        }
+        return;
+    }
+
+    if (transmitting_)
+        return;
+
+    if (!scanning_)
+        return;
+
+    freq_index_ = (freq_index_ + 1) % freqs_.size();
+    current_freq_ = freqs_[freq_index_];
+    receiver_model.set_target_frequency(current_freq_);
+    field_frequency.set_value(current_freq_);
+
+    if (rssi.get_max() > 50) {
+        text_status.set("Signal " + to_string_short_freq(current_freq_));
+        baseband::request_audio_beep(2000, 24000, 60);
+        start_capture();
+    }
+}
+
+void KeyfobScanView::start_capture() {
+    if (capture_thread_)
+        return;
+
+    ensure_directory(captures_dir);
+    rtc::RTC now;
+    rtc_time::now(now);
+    last_capture_path_ = captures_dir / (std::string("KF_") + to_string_timestamp(now) + ".C8");
+
+    auto writer = std::make_unique<FileConvertWriter>();
+    auto error = writer->create(last_capture_path_);
+    if (error) {
+        text_status.set("SD error");
+        return;
+    }
+
+    baseband::shutdown();
+    baseband::run_image(portapack::spi_flash::image_tag_capture);
+    baseband::set_sample_rate(capture_rate_, get_oversample_rate(capture_rate_));
+
+    capture_thread_ = std::make_unique<CaptureThread>(
+        std::move(writer), 0x4000, 3,
+        []() {
+            CaptureThreadDoneMessage message{};
+            EventDispatcher::send_message(message);
+        },
+        [](File::Error error) {
+            CaptureThreadDoneMessage message{error.code()};
+            EventDispatcher::send_message(message);
+        });
+
+    capture_seconds_left_ = 1;
+    capturing_ = true;
+    text_status.set("Capturing");
+}
+
+void KeyfobScanView::stop_capture() {
+    if (!capture_thread_)
+        return;
+
+    capture_thread_.reset();
+    baseband::shutdown();
+    baseband::run_image(portapack::spi_flash::image_tag_subghzd);
+    baseband::set_subghzd_config(0, receiver_model.sampling_rate());
+    receiver_model.enable();
+    capturing_ = false;
+    button_transmit.disabled(false);
+    text_status.set("Captured");
+}
+
+void KeyfobScanView::transmit_last() {
+    if (transmitting_ || last_capture_path_.empty())
+        return;
+
+    auto reader = std::make_unique<FileConvertReader>();
+    auto error = reader->open(last_capture_path_);
+    if (error) {
+        text_status.set("Open error");
+        return;
+    }
+
+    baseband::shutdown();
+    baseband::run_image(portapack::spi_flash::image_tag_replay);
+    baseband::set_sample_rate(capture_rate_, get_oversample_rate(capture_rate_));
+
+    transmitter_model.set_target_frequency(current_freq_);
+    transmitter_model.set_sampling_rate(get_actual_sample_rate(capture_rate_));
+    transmitter_model.set_baseband_bandwidth(2'500'000);
+    transmitter_model.enable();
+
+    replay_thread_ = std::make_unique<ReplayThread>(
+        std::move(reader), 0x4000, 3, &ready_signal_,
+        [](uint32_t return_code) {
+            ReplayThreadDoneMessage message{return_code};
+            EventDispatcher::send_message(message);
+        });
+
+    transmitting_ = true;
+    text_status.set("Transmitting");
+}
+
+void KeyfobScanView::stop_transmit() {
+    if (!transmitting_)
+        return;
+
+    replay_thread_.reset();
+    transmitter_model.disable();
+    baseband::shutdown();
+    baseband::run_image(portapack::spi_flash::image_tag_subghzd);
+    baseband::set_subghzd_config(0, receiver_model.sampling_rate());
+    receiver_model.enable();
+    transmitting_ = false;
+    ready_signal_ = false;
+    text_status.set("Done");
+}
+
+}  // namespace ui

--- a/firmware/application/apps/ui_keyfob_scan.hpp
+++ b/firmware/application/apps/ui_keyfob_scan.hpp
@@ -1,0 +1,75 @@
+#ifndef __UI_KEYFOB_SCAN_H__
+#define __UI_KEYFOB_SCAN_H__
+
+#include "ui.hpp"
+#include "ui_navigation.hpp"
+#include "ui_receiver.hpp"
+#include "ui_freq_field.hpp"
+#include "ui_rssi.hpp"
+#include "string_format.hpp"
+#include "rtc_time.hpp"
+#include "baseband_api.hpp"
+#include "capture_thread.hpp"
+#include "replay_thread.hpp"
+#include "io_convert.hpp"
+#include "oversample.hpp"
+#include "file_path.hpp"
+#include "transmitter_model.hpp"
+
+namespace ui {
+
+class KeyfobScanView : public View {
+   public:
+    KeyfobScanView(NavigationView& nav);
+    ~KeyfobScanView();
+    void focus() override;
+    std::string title() const override { return "Keyfob Scan"; }
+
+   private:
+    void on_tick_second();
+    void toggle_scanning();
+    void start_capture();
+    void stop_capture();
+    void transmit_last();
+    void stop_transmit();
+
+    NavigationView& nav_;
+    bool scanning_{false};
+    bool capturing_{false};
+    bool transmitting_{false};
+    size_t freq_index_{0};
+    uint32_t capture_seconds_left_{0};
+    uint32_t capture_rate_{2'000'000};
+    rf::Frequency current_freq_{0};
+    std::filesystem::path last_capture_path_{};
+    bool ready_signal_{false};
+    std::unique_ptr<CaptureThread> capture_thread_{};
+    std::unique_ptr<ReplayThread> replay_thread_{};
+    rtc_time::SignalToken signal_token_tick_second{};
+    MessageHandlerRegistration message_handler_replay_done{
+        Message::ID::ReplayThreadDone,
+        [this](const Message* const p) {
+            (void)p;
+            this->stop_transmit();
+        }};
+    MessageHandlerRegistration message_handler_fifo_signal{
+        Message::ID::RequestSignal,
+        [this](const Message* const p) {
+            const auto message = static_cast<const RequestSignalMessage*>(p);
+            if (message->signal == RequestSignalMessage::Signal::FillRequest)
+                ready_signal_ = true;
+        }};
+
+    std::array<rf::Frequency, 6> freqs_{
+        {305000000, 315000000, 390000000, 433920000, 868300000, 915000000}};
+
+    RSSI rssi{{8, 3 * 16, 30 * 8, 16}, false};
+    RxFrequencyField field_frequency{{2 * 8, 1 * 16}, nav};
+    Button button_toggle{{2 * 8, 5 * 16, 8 * 16, 32}, "Start"};
+    Button button_transmit{{14 * 8, 5 * 16, 8 * 16, 32}, "Transmit"};
+    Text text_status{{2 * 8, 7 * 16, 30 * 8, 16}, "Stopped"};
+};
+
+}  // namespace ui
+
+#endif  // __UI_KEYFOB_SCAN_H__

--- a/firmware/application/ui_navigation.cpp
+++ b/firmware/application/ui_navigation.cpp
@@ -61,6 +61,7 @@
 #include "ui_touchtunes.hpp"
 #include "ui_weatherstation.hpp"
 #include "ui_subghzd.hpp"
+#include "ui_keyfob_scan.hpp"
 #include "ui_battinfo.hpp"
 #include "ui_external_items_menu_loader.hpp"
 
@@ -136,6 +137,7 @@ const NavigationView::AppList NavigationView::appList = {
     {"radiosonde", "Radiosnde", RX, Color::green(), &bitmap_icon_sonde, new ViewFactory<SondeView>()},
     {"search", "Search", RX, Color::yellow(), &bitmap_icon_search, new ViewFactory<SearchView>()},
     {"subghzd", "SubGhzD", RX, Color::yellow(), &bitmap_icon_remote, new ViewFactory<SubGhzDView>()},
+    {"keyfobscan", "Keyfob Scan", RX, Color::yellow(), &bitmap_icon_remote, new ViewFactory<KeyfobScanView>()},
     {"weather", "Weather", RX, Color::green(), &bitmap_icon_thermometer, new ViewFactory<WeatherView>()},
     /* TX ********************************************************************/
     {"aprstx", "APRS TX", TX, ui::Color::green(), &bitmap_icon_aprs, new ViewFactory<APRSTXView>()},


### PR DESCRIPTION
## Summary
- add KeyfobScanView implementation and header
- compile it in the application build
- expose Keyfob Scan in navigation menu

## Testing
- `./format-code.sh` *(fails: clang-format-13 missing)*
- `ctest --output-on-failure` *(no tests found)*